### PR TITLE
Filter control for what models on main tab

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -429,7 +429,7 @@ describe("App", () => {
   })
 
   it("skips saving settings when already normalized", async () => {
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
     render(<App />)
     await waitFor(() => expect(state.invokeMock).toHaveBeenCalledWith("list_plugins"))
     expect((await screen.findAllByText("Alpha")).length).toBeGreaterThan(0)
@@ -465,7 +465,7 @@ describe("App", () => {
       }
       return null
     })
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [], disabledOverviewLabels: {} })
 
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
@@ -503,7 +503,7 @@ describe("App", () => {
       }
       return null
     })
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
 
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
@@ -537,7 +537,7 @@ describe("App", () => {
       }
       return null
     })
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
 
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
@@ -573,7 +573,7 @@ describe("App", () => {
       }
       return null
     })
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
 
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
@@ -628,7 +628,7 @@ describe("App", () => {
       }
       return null
     })
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
 
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
@@ -948,7 +948,7 @@ describe("App", () => {
   })
 
   it("reloads plugin from sidebar context menu", async () => {
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
     state.probeHandlers?.onResult({
@@ -970,7 +970,7 @@ describe("App", () => {
   })
 
   it("respects manual refresh cooldown for sidebar context menu reload", async () => {
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
     state.probeHandlers?.onResult({
@@ -1043,7 +1043,7 @@ describe("App", () => {
   })
 
   it("removes plugin from sidebar context menu", async () => {
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
     state.startBatchMock.mockClear()
@@ -1054,14 +1054,14 @@ describe("App", () => {
     removeAction()
 
     await waitFor(() =>
-      expect(state.savePluginSettingsMock).toHaveBeenCalledWith({ order: ["a", "b"], disabled: ["b"] })
+      expect(state.savePluginSettingsMock).toHaveBeenCalledWith({ order: ["a", "b"], disabled: ["b"], disabledOverviewLabels: {} })
     )
     expect(state.trackMock).toHaveBeenCalledWith("provider_toggled", { provider_id: "b", enabled: "false" })
     expect(state.startBatchMock).not.toHaveBeenCalled()
   })
 
   it("ignores removing an already disabled plugin from context menu", async () => {
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
     state.trackMock.mockClear()
@@ -1070,7 +1070,7 @@ describe("App", () => {
     const removeAction = await triggerPluginContextAction("Beta", "b", "remove")
     removeAction()
     await waitFor(() =>
-      expect(state.savePluginSettingsMock).toHaveBeenCalledWith({ order: ["a", "b"], disabled: ["b"] })
+      expect(state.savePluginSettingsMock).toHaveBeenCalledWith({ order: ["a", "b"], disabled: ["b"], disabledOverviewLabels: {} })
     )
     await waitFor(() =>
       expect(screen.queryByRole("button", { name: "Beta" })).not.toBeInTheDocument()
@@ -1084,7 +1084,7 @@ describe("App", () => {
   })
 
   it("returns to home when removing the active plugin from context menu", async () => {
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [], disabledOverviewLabels: {} })
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
     state.savePluginSettingsMock.mockClear()
@@ -1103,7 +1103,7 @@ describe("App", () => {
   })
 
   it("shows empty state when all plugins disabled", async () => {
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: ["a", "b"] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: ["a", "b"], disabledOverviewLabels: {} })
     render(<App />)
     await screen.findByText("No providers enabled")
     expect(screen.getByText("Paused")).toBeInTheDocument()
@@ -1134,7 +1134,7 @@ describe("App", () => {
 
   it("handles enable toggle failures", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: ["b"] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: ["b"], disabledOverviewLabels: {} })
     state.startBatchMock
       .mockResolvedValueOnce(["a"])
       .mockRejectedValueOnce(new Error("enable fail"))
@@ -1151,7 +1151,7 @@ describe("App", () => {
   })
 
   it("enables disabled plugin and starts batch", async () => {
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: ["b"] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: ["b"], disabledOverviewLabels: {} })
     render(<App />)
     const settingsButtons = await screen.findAllByRole("button", { name: "Settings" })
     await userEvent.click(settingsButtons[0])
@@ -1194,7 +1194,7 @@ describe("App", () => {
   })
 
   it("logs when saving plugin order fails", async () => {
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
     state.savePluginSettingsMock.mockRejectedValueOnce(new Error("save order"))
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     render(<App />)
@@ -1233,7 +1233,7 @@ describe("App", () => {
   })
 
   it("coalesces pending tray icon timers on multiple settings changes", async () => {
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
     render(<App />)
     const settingsButtons = await screen.findAllByRole("button", { name: "Settings" })
     await userEvent.click(settingsButtons[0])
@@ -1290,7 +1290,7 @@ describe("App", () => {
 
   it("sets next update to null when changing interval with all plugins disabled", async () => {
     // All plugins disabled
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: ["a", "b"] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: ["a", "b"], disabledOverviewLabels: {} })
     render(<App />)
 
     // Go to settings
@@ -1306,7 +1306,7 @@ describe("App", () => {
   it("covers interval change branch when plugins exist", async () => {
     // This test ensures the interval change logic is exercised with enabled plugins
     // to cover the if branch (enabledIds.length > 0 sets nextAt)
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
     render(<App />)
 
     const settingsButtons = await screen.findAllByRole("button", { name: "Settings" })
@@ -1321,7 +1321,7 @@ describe("App", () => {
   it("fires auto-update interval and schedules next", async () => {
     vi.useFakeTimers()
     state.loadAutoUpdateIntervalMock.mockResolvedValueOnce(5)
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [], disabledOverviewLabels: {} })
 
     render(<App />)
 
@@ -1347,7 +1347,7 @@ describe("App", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
 
     state.loadAutoUpdateIntervalMock.mockResolvedValueOnce(5)
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [], disabledOverviewLabels: {} })
     // First call succeeds (initial batch), subsequent calls fail
     state.startBatchMock
       .mockResolvedValueOnce(["a"])
@@ -1400,7 +1400,7 @@ describe("App", () => {
   })
 
   it("refreshes all enabled providers when clicking next update label", async () => {
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
     state.probeHandlers?.onResult({
@@ -1429,7 +1429,7 @@ describe("App", () => {
   })
 
   it("ignores repeated refresh-all clicks while providers are already refreshing", async () => {
-    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [] })
+    state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a", "b"], disabled: [], disabledOverviewLabels: {} })
     render(<App />)
     await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
     state.probeHandlers?.onResult({
@@ -1464,7 +1464,7 @@ describe("App", () => {
   it("does not leak manual refresh cooldown state when refresh-all start fails", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
     try {
-      state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [] })
+      state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [], disabledOverviewLabels: {} })
       render(<App />)
       await waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
       state.probeHandlers?.onResult({
@@ -1704,7 +1704,7 @@ describe("App", () => {
         }
         return null
       })
-      state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [] })
+      state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [], disabledOverviewLabels: {} })
       state.renderTrayBarsIconMock
         .mockReturnValueOnce(firstRender)
         .mockResolvedValueOnce({})
@@ -1767,7 +1767,7 @@ describe("App", () => {
         }
         return null
       })
-      state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [] })
+      state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [], disabledOverviewLabels: {} })
 
       const { unmount } = render(<App />)
       await vi.waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())
@@ -1810,7 +1810,7 @@ describe("App", () => {
         }
         return null
       })
-      state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [] })
+      state.loadPluginSettingsMock.mockResolvedValueOnce({ order: ["a"], disabled: [], disabledOverviewLabels: {} })
 
       render(<App />)
       await vi.waitFor(() => expect(state.startBatchMock).toHaveBeenCalled())

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,6 +158,7 @@ function App() {
   const {
     handleReorder,
     handleToggle,
+    handleToggleOverviewLabel,
   } = useSettingsPluginActions({
     pluginSettings,
     setPluginSettings,
@@ -241,6 +242,7 @@ function App() {
         onRetryPlugin: handleRetryPlugin,
         onReorder: handleReorder,
         onToggle: handleToggle,
+        onToggleOverviewLabel: handleToggleOverviewLabel,
         onAutoUpdateIntervalChange: handleAutoUpdateIntervalChange,
         onThemeModeChange: handleThemeModeChange,
         onDisplayModeChange: handleDisplayModeChange,

--- a/src/components/app/app-content.tsx
+++ b/src/components/app/app-content.tsx
@@ -26,6 +26,7 @@ export type AppContentActionProps = {
   onRetryPlugin: (id: string) => void
   onReorder: (orderedIds: string[]) => void
   onToggle: (id: string) => void
+  onToggleOverviewLabel: (pluginId: string, label: string) => void
   onAutoUpdateIntervalChange: (value: AutoUpdateIntervalMinutes) => void
   onThemeModeChange: (mode: ThemeMode) => void
   onDisplayModeChange: (mode: DisplayMode) => void
@@ -46,6 +47,7 @@ export function AppContent({
   onRetryPlugin,
   onReorder,
   onToggle,
+  onToggleOverviewLabel,
   onAutoUpdateIntervalChange,
   onThemeModeChange,
   onDisplayModeChange,
@@ -100,6 +102,7 @@ export function AppContent({
         plugins={settingsPlugins}
         onReorder={onReorder}
         onToggle={onToggle}
+        onToggleOverviewLabel={onToggleOverviewLabel}
         autoUpdateInterval={autoUpdateInterval}
         onAutoUpdateIntervalChange={onAutoUpdateIntervalChange}
         themeMode={themeMode}

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -33,6 +33,7 @@ interface ProviderCardProps {
   onRetry?: () => void
   scopeFilter?: "overview" | "all"
   displayMode: DisplayMode
+  disabledOverviewLabels?: string[]
   resetTimerDisplayMode?: ResetTimerDisplayMode
   onResetTimerDisplayModeToggle?: () => void
 }
@@ -98,6 +99,7 @@ export function ProviderCard({
   displayMode,
   resetTimerDisplayMode = "relative",
   onResetTimerDisplayModeToggle,
+  disabledOverviewLabels = [],
 }: ProviderCardProps) {
   const cooldownRemainingMs = useMemo(() => {
     if (!lastManualRefreshAt) return 0
@@ -106,14 +108,15 @@ export function ProviderCard({
   }, [lastManualRefreshAt])
 
   // Filter lines based on scope - match by label since runtime lines can differ from manifest
+  const disabledSet = new Set(disabledOverviewLabels)
   const overviewLabels = new Set(
     skeletonLines
-      .filter(line => line.scope === "overview")
+      .filter(line => line.scope === "overview" && !disabledSet.has(line.label))
       .map(line => line.label)
   )
   const filteredSkeletonLines = scopeFilter === "all"
     ? skeletonLines
-    : skeletonLines.filter(line => line.scope === "overview")
+    : skeletonLines.filter(line => line.scope === "overview" && !disabledSet.has(line.label))
   const filteredLines = scopeFilter === "all"
     ? lines
     : lines.filter(line => overviewLabels.has(line.label))

--- a/src/hooks/app/use-app-plugin-views.ts
+++ b/src/hooks/app/use-app-plugin-views.ts
@@ -4,7 +4,7 @@ import type { PluginMeta } from "@/lib/plugin-types"
 import type { PluginSettings } from "@/lib/settings"
 import type { PluginState } from "@/hooks/app/types"
 
-export type DisplayPluginState = { meta: PluginMeta } & PluginState
+export type DisplayPluginState = { meta: PluginMeta; disabledOverviewLabels: string[] } & PluginState
 
 type UseAppPluginViewsArgs = {
   activeView: ActiveView
@@ -33,7 +33,7 @@ export function useAppPluginViews({
         if (!meta) return null
         const state =
           pluginStates[id] ?? { data: null, loading: false, error: null, lastManualRefreshAt: null }
-        return { meta, ...state }
+        return { meta, ...state, disabledOverviewLabels: pluginSettings.disabledOverviewLabels?.[id] || [] }
       })
       .filter((plugin): plugin is DisplayPluginState => Boolean(plugin))
   }, [pluginSettings, pluginStates, pluginsMeta])

--- a/src/hooks/app/use-settings-plugin-actions.ts
+++ b/src/hooks/app/use-settings-plugin-actions.ts
@@ -91,8 +91,32 @@ export function useSettingsPluginActions({
     startBatch,
   ])
 
+  const handleToggleOverviewLabel = useCallback((pluginId: string, label: string) => {
+    if (!pluginSettings) return
+    const currentDisabled = pluginSettings.disabledOverviewLabels?.[pluginId] || []
+    const isCurrentlyDisabled = currentDisabled.includes(label)
+    
+    const nextDisabled = isCurrentlyDisabled
+      ? currentDisabled.filter((l) => l !== label)
+      : [...currentDisabled, label]
+
+    const nextSettings: PluginSettings = {
+      ...pluginSettings,
+      disabledOverviewLabels: {
+        ...pluginSettings.disabledOverviewLabels,
+        [pluginId]: nextDisabled,
+      },
+    }
+
+    setPluginSettings(nextSettings)
+    scheduleTrayIconUpdate("settings", TRAY_SETTINGS_DEBOUNCE_MS)
+    void savePluginSettings(nextSettings).catch((error) => {
+      console.error("Failed to save plugin overview label toggle:", error)
+    })
+  }, [pluginSettings, scheduleTrayIconUpdate, setPluginSettings])
   return {
     handleReorder,
     handleToggle,
+    handleToggleOverviewLabel,
   }
 }

--- a/src/hooks/app/use-settings-plugin-list.test.ts
+++ b/src/hooks/app/use-settings-plugin-list.test.ts
@@ -20,6 +20,7 @@ describe("useSettingsPluginList", () => {
     const pluginSettings: PluginSettings = {
       order: ["codex", "missing", "cursor"],
       disabled: ["cursor"],
+      disabledOverviewLabels: {},
     }
 
     const { result } = renderHook(() =>
@@ -33,8 +34,8 @@ describe("useSettingsPluginList", () => {
     )
 
     expect(result.current).toEqual([
-      { id: "codex", name: "Codex", enabled: true },
-      { id: "cursor", name: "Cursor", enabled: false },
+      { id: "codex", name: "Codex", enabled: true, lines: [], disabledOverviewLabels: [] },
+      { id: "cursor", name: "Cursor", enabled: false, lines: [], disabledOverviewLabels: [] },
     ])
   })
 

--- a/src/hooks/app/use-settings-plugin-list.ts
+++ b/src/hooks/app/use-settings-plugin-list.ts
@@ -1,11 +1,13 @@
 import { useMemo } from "react"
-import type { PluginMeta } from "@/lib/plugin-types"
+import type { ManifestLine, PluginMeta } from "@/lib/plugin-types"
 import type { PluginSettings } from "@/lib/settings"
 
 export type SettingsPluginState = {
   id: string
   name: string
   enabled: boolean
+  lines: ManifestLine[]
+  disabledOverviewLabels: string[]
 }
 
 type UseSettingsPluginListArgs = {
@@ -26,6 +28,8 @@ export function useSettingsPluginList({ pluginSettings, pluginsMeta }: UseSettin
           id,
           name: meta.name,
           enabled: !pluginSettings.disabled.includes(id),
+          lines: meta.lines,
+          disabledOverviewLabels: pluginSettings.disabledOverviewLabels?.[id] || [],
         }
       })
       .filter((plugin): plugin is SettingsPluginState => Boolean(plugin))

--- a/src/lib/plugin-types.ts
+++ b/src/lib/plugin-types.ts
@@ -53,4 +53,5 @@ export type PluginDisplayState = {
   loading: boolean
   error: string | null
   lastManualRefreshAt: number | null
+  disabledOverviewLabels?: string[]
 }

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -70,13 +70,14 @@ describe("settings", () => {
     await expect(loadPluginSettings()).resolves.toEqual({
       order: ["a"],
       disabled: [],
+      disabledOverviewLabels: {},
     })
   })
 
   it("saves settings", async () => {
     const settings = { order: ["a"], disabled: ["b"] }
     await savePluginSettings(settings)
-    await expect(loadPluginSettings()).resolves.toEqual(settings)
+    await expect(loadPluginSettings()).resolves.toEqual({ ...settings, disabledOverviewLabels: {} })
   })
 
   it("normalizes order + disabled against known plugins", () => {
@@ -88,7 +89,7 @@ describe("settings", () => {
       { order: ["b", "b", "c"], disabled: ["c", "a"] },
       plugins
     )
-    expect(normalized).toEqual({ order: ["b", "a"], disabled: ["a"] })
+    expect(normalized).toEqual({ order: ["b", "a"], disabled: ["a"], disabledOverviewLabels: {} })
   })
 
   it("auto-disables new non-default plugins", () => {
@@ -100,6 +101,17 @@ describe("settings", () => {
     const result = normalizePluginSettings({ order: [], disabled: [] }, plugins)
     expect(result.order).toEqual(["claude", "copilot", "windsurf"])
     expect(result.disabled).toEqual(["copilot", "windsurf"])
+  })
+
+  it("normalizes disabledOverviewLabels by keeping only known plugin keys", () => {
+    const plugins: PluginMeta[] = [
+      { id: "a", name: "A", iconUrl: "", lines: [], primaryCandidates: [] },
+    ]
+    const normalized = normalizePluginSettings(
+      { order: [], disabled: [], disabledOverviewLabels: { "a": ["L1"], "unknown": ["L2"] } },
+      plugins
+    )
+    expect(normalized.disabledOverviewLabels).toEqual({ "a": ["L1"] })
   })
 
   it("keeps the mock plugin enabled when it is the only available shell-spike provider", () => {
@@ -114,11 +126,13 @@ describe("settings", () => {
   })
 
   it("compares settings equality", () => {
-    const a = { order: ["a"], disabled: [] }
-    const b = { order: ["a"], disabled: [] }
-    const c = { order: ["b"], disabled: [] }
+    const a: PluginSettings = { order: ["a"], disabled: [], disabledOverviewLabels: { "a": ["L1"] } }
+    const b: PluginSettings = { order: ["a"], disabled: [], disabledOverviewLabels: { "a": ["L1"] } }
+    const c: PluginSettings = { order: ["b"], disabled: [], disabledOverviewLabels: { "a": ["L1"] } }
+    const d: PluginSettings = { order: ["a"], disabled: [], disabledOverviewLabels: { "a": ["L2"] } }
     expect(arePluginSettingsEqual(a, b)).toBe(true)
     expect(arePluginSettingsEqual(a, c)).toBe(false)
+    expect(arePluginSettingsEqual(a, d)).toBe(false)
   })
 
   it("returns enabled plugin ids", () => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -8,6 +8,7 @@ export const REFRESH_COOLDOWN_MS = 300_000;
 export type PluginSettings = {
   order: string[];
   disabled: string[];
+  disabledOverviewLabels?: Record<string, string[]>;
 };
 
 export type AutoUpdateIntervalMinutes = 5 | 15 | 30 | 60;
@@ -83,6 +84,7 @@ const DEFAULT_ENABLED_PLUGINS = new Set(["claude", "codex", "cursor"]);
 export const DEFAULT_PLUGIN_SETTINGS: PluginSettings = {
   order: [],
   disabled: [],
+  disabledOverviewLabels: {},
 };
 
 export async function loadPluginSettings(): Promise<PluginSettings> {
@@ -91,6 +93,7 @@ export async function loadPluginSettings(): Promise<PluginSettings> {
   return {
     order: Array.isArray(stored.order) ? stored.order : [],
     disabled: Array.isArray(stored.disabled) ? stored.disabled : [],
+    disabledOverviewLabels: stored.disabledOverviewLabels || {},
   };
 }
 
@@ -150,7 +153,16 @@ export function normalizePluginSettings(
       disabled.push(id);
     }
   }
-  return { order, disabled };
+  const disabledOverviewLabels: Record<string, string[]> = {};
+  if (settings.disabledOverviewLabels) {
+    for (const [id, labels] of Object.entries(settings.disabledOverviewLabels)) {
+      if (knownSet.has(id) && Array.isArray(labels)) {
+        disabledOverviewLabels[id] = labels;
+      }
+    }
+  }
+
+  return { order, disabled, disabledOverviewLabels };
 }
 
 export function arePluginSettingsEqual(
@@ -164,6 +176,19 @@ export function arePluginSettingsEqual(
   }
   for (let i = 0; i < a.disabled.length; i += 1) {
     if (a.disabled[i] !== b.disabled[i]) return false;
+  }
+  const aLabels = a.disabledOverviewLabels || {};
+  const bLabels = b.disabledOverviewLabels || {};
+  const aKeys = Object.keys(aLabels);
+  const bKeys = Object.keys(bLabels);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    const aList = aLabels[key];
+    const bList = bLabels[key];
+    if (!bList || aList.length !== bList.length) return false;
+    for (let i = 0; i < aList.length; i += 1) {
+      if (aList[i] !== bList[i]) return false;
+    }
   }
   return true;
 }

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -45,6 +45,7 @@ export function OverviewPage({
           displayMode={displayMode}
           resetTimerDisplayMode={resetTimerDisplayMode}
           onResetTimerDisplayModeToggle={onResetTimerDisplayModeToggle}
+          disabledOverviewLabels={plugin.disabledOverviewLabels}
         />
       ))}
     </div>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -40,6 +40,8 @@ interface PluginConfig {
   id: string;
   name: string;
   enabled: boolean;
+  lines: import("@/lib/plugin-types").ManifestLine[];
+  disabledOverviewLabels: string[];
 }
 
 const TRAY_PREVIEW_SIZE_PX = getTrayIconSizePx(1);
@@ -196,9 +198,11 @@ function MenubarIconStylePreview({
 function SortablePluginItem({
   plugin,
   onToggle,
+  onToggleOverviewLabel,
 }: {
   plugin: PluginConfig;
   onToggle: (id: string) => void;
+  onToggleOverviewLabel: (pluginId: string, label: string) => void;
 }) {
   const {
     attributes,
@@ -208,45 +212,61 @@ function SortablePluginItem({
     transition,
     isDragging,
   } = useSortable({ id: plugin.id });
-
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
   };
 
+  const overviewLines = plugin.lines ? plugin.lines.filter((l) => l.scope === "overview") : [];
   return (
     <div
       ref={setNodeRef}
       style={style}
       className={cn(
-        "flex items-center gap-3 px-3 py-2 rounded-md bg-card",
-        "border border-transparent",
+        "flex flex-col gap-2 px-3 py-2 rounded-md bg-card border border-transparent",
         isDragging && "opacity-50 border-border"
       )}
     >
-      <button
-        type="button"
-        className="touch-none cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground transition-colors"
-        {...attributes}
-        {...listeners}
-      >
-        <GripVertical className="h-4 w-4" />
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          className="touch-none cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground transition-colors"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="h-4 w-4" />
       </button>
-
-      <span
-        className={cn(
-          "flex-1 text-sm",
-          !plugin.enabled && "text-muted-foreground"
-        )}
-      >
-        {plugin.name}
-      </span>
-
-      <Checkbox
-        key={`${plugin.id}-${plugin.enabled}`}
-        checked={plugin.enabled}
-        onCheckedChange={() => onToggle(plugin.id)}
-      />
+        <span
+          className={cn(
+            "flex-1 text-sm",
+            !plugin.enabled && "text-muted-foreground"
+          )}
+        >
+          {plugin.name}
+        </span>
+        <Checkbox
+          key={`${plugin.id}-${plugin.enabled}`}
+          checked={plugin.enabled}
+          onCheckedChange={() => onToggle(plugin.id)}
+        />
+      </div>
+      {plugin.enabled && overviewLines.length > 0 && (
+        <div className="flex flex-col gap-1.5 pl-7 pr-1 pb-1">
+          {overviewLines.map((line) => {
+            const isLineEnabled = !plugin.disabledOverviewLabels.includes(line.label);
+            return (
+              <label key={line.label} className="flex items-center gap-2 text-xs select-none text-muted-foreground hover:text-foreground transition-colors cursor-pointer">
+                <Checkbox
+                  checked={isLineEnabled}
+                  onCheckedChange={() => onToggleOverviewLabel(plugin.id, line.label)}
+                  className="h-3.5 w-3.5"
+                />
+                {line.label}
+              </label>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }
@@ -255,6 +275,7 @@ interface SettingsPageProps {
   plugins: PluginConfig[];
   onReorder: (orderedIds: string[]) => void;
   onToggle: (id: string) => void;
+  onToggleOverviewLabel: (pluginId: string, label: string) => void;
   autoUpdateInterval: AutoUpdateIntervalMinutes;
   onAutoUpdateIntervalChange: (value: AutoUpdateIntervalMinutes) => void;
   themeMode: ThemeMode;
@@ -276,6 +297,7 @@ export function SettingsPage({
   plugins,
   onReorder,
   onToggle,
+  onToggleOverviewLabel,
   autoUpdateInterval,
   onAutoUpdateIntervalChange,
   themeMode,
@@ -504,6 +526,7 @@ export function SettingsPage({
                   key={plugin.id}
                   plugin={plugin}
                   onToggle={onToggle}
+                  onToggleOverviewLabel={onToggleOverviewLabel}
                 />
               ))}
             </SortableContext>


### PR DESCRIPTION
## Description

This allows you to exclude certain models from the main tab in order to help make it more concise.    You can still see all models on the individual provider's tab.

## Related Issue

<!-- Link to the issue this PR addresses: Fixes #123 -->

## Type of Change

- [ ] Bug fix
- [x ] New feature
- [ ] New provider plugin
- [ ] Documentation
- [ ] Performance improvement
- [ ] Other (describe below)

## Testing

- [X] I ran `bun run build` and it succeeded
- [X] I ran `bun run test` and all tests pass
- [X] I tested the change locally with `bun tauri dev`


## Screenshots

The main with filtered models:
<img width="200" height="446" alt="image" src="https://github.com/user-attachments/assets/d135ff69-d552-454d-84b3-fad876684598" />

The settings to pick what models (only shows the model selection when the provider is enabled):
<img width="270" height="382" alt="image" src="https://github.com/user-attachments/assets/9bd66abe-334c-4668-a39b-bbb58ca53df0" />


## Checklist

- [X] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] My PR targets the `main` branch
- [X] I did not introduce new dependencies without justification


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-provider controls to hide specific model lines on the Overview tab, making the main tab more concise. Settings are saved and do not affect provider-specific tabs.

- **New Features**
  - In Settings, enabled providers show checkboxes for each `scope: "overview"` line to include/exclude them on Overview.
  - Added `disabledOverviewLabels` to plugin settings with persistence, normalization, and equality checks.
  - Overview filters out disabled labels in `ProviderCard`; provider tabs remain unchanged. Wiring added via `onToggleOverviewLabel` through `App`, `AppContent`, and hooks.

<sup>Written for commit 7361b98f76a47dcaab2158aa4eb8953542653afa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

