### PR TITLE
feat: add 7-day usage trend charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you don't want to install the binary, or you want to develop on the project, 
 UsageTray lives in your Windows tray and shows usage data for supported AI coding tools in a single popup panel.
 
 - One-glance usage visibility across supported providers
+- 7-day usage trend charts per provider
 - Automatic refresh on a configurable schedule
 - Global shortcut support
 - Single-popup tray UI

--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -1,0 +1,13 @@
+# Breadcrumbs
+
+## 2026-04-14
+
+- Reviewing PRs #18 and #19 for merge/release.
+- PR #19 blocked by Factory `auth.v2` crypto API mismatch between plugin code, host wrapper, and test helper.
+- Applying a minimal fix so `auth.v2` load/save behavior is consistent across runtime and tests before merge/release.
+
+## 2026-04-21
+
+- Added persisted 7-day usage history snapshots keyed by provider/day using the existing frontend store layer.
+- Wired successful probe results to update local history and exposed history through app plugin view state.
+- Added inline provider trend charts in overview/detail plus regression coverage for history derivation, persistence, and App/bootstrap wiring.

--- a/docs/choices.md
+++ b/docs/choices.md
@@ -1,0 +1,9 @@
+# Choices
+
+## 2026-04-14
+
+- PR #19 fix scope: minimal consistency pass for Factory `auth.v2` only. Kept release-moving work focused on the concrete regression instead of broad upstream cleanup.
+
+## 2026-04-21
+
+- Usage history stores one snapshot per provider per local day. Latest successful probe wins for that day; chart stays small, stable, and persistence stays bounded to the rolling 7-day window.

--- a/plugins/claude/plugin.test.js
+++ b/plugins/claude/plugin.test.js
@@ -10,6 +10,7 @@ describe("claude plugin", () => {
   beforeEach(() => {
     delete globalThis.__openusage_plugin
     vi.resetModules()
+    vi.useRealTimers()
   })
 
   it("throws when no credentials", async () => {
@@ -1072,6 +1073,7 @@ describe("claude plugin", () => {
     })
 
     it("matches UTC timestamp day keys at month boundary (regression)", async () => {
+      const plugin = await loadPlugin()
       vi.useFakeTimers()
       vi.setSystemTime(new Date(2026, 2, 1, 12, 0, 0))
       try {
@@ -1080,7 +1082,6 @@ describe("claude plugin", () => {
               { date: "2026-03-01T12:00:00Z", inputTokens: 10, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 10, totalCost: 0.1 },
             ]),
         })
-        const plugin = await loadPlugin()
         const result = plugin.probe(ctx)
         const todayLine = result.lines.find((l) => l.label === "Today")
         expect(todayLine).toBeTruthy()
@@ -1091,6 +1092,7 @@ describe("claude plugin", () => {
     })
 
     it("matches UTC+9 timestamp day keys at month boundary (regression)", async () => {
+      const plugin = await loadPlugin()
       vi.useFakeTimers()
       vi.setSystemTime(new Date(2026, 2, 1, 12, 0, 0))
       try {
@@ -1099,7 +1101,6 @@ describe("claude plugin", () => {
               { date: "2026-03-01T00:30:00+09:00", inputTokens: 20, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 20, totalCost: 0.2 },
             ]),
         })
-        const plugin = await loadPlugin()
         const result = plugin.probe(ctx)
         const todayLine = result.lines.find((l) => l.label === "Today")
         expect(todayLine).toBeTruthy()
@@ -1110,6 +1111,7 @@ describe("claude plugin", () => {
     })
 
     it("matches UTC-8 timestamp day keys at day boundary (regression)", async () => {
+      const plugin = await loadPlugin()
       vi.useFakeTimers()
       vi.setSystemTime(new Date(2026, 2, 1, 12, 0, 0))
       try {
@@ -1118,7 +1120,6 @@ describe("claude plugin", () => {
               { date: "2026-03-01T23:30:00-08:00", inputTokens: 30, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 30, totalCost: 0.3 },
             ]),
         })
-        const plugin = await loadPlugin()
         const result = plugin.probe(ctx)
         const todayLine = result.lines.find((l) => l.label === "Today")
         expect(todayLine).toBeTruthy()
@@ -1241,11 +1242,11 @@ describe("claude plugin", () => {
     })
 
     it("queries ccusage with a 31-day inclusive since window", async () => {
+      const plugin = await loadPlugin()
       vi.useFakeTimers()
       vi.setSystemTime(new Date("2026-02-20T16:00:00.000Z"))
       try {
         const ctx = makeProbeCtx({ ccusageResult: okUsage([]) })
-        const plugin = await loadPlugin()
         plugin.probe(ctx)
         expect(ctx.host.ccusage.query).toHaveBeenCalled()
 

--- a/plugins/codex/plugin.test.js
+++ b/plugins/codex/plugin.test.js
@@ -10,6 +10,7 @@ describe("codex plugin", () => {
   beforeEach(() => {
     delete globalThis.__openusage_plugin
     vi.resetModules()
+    vi.useRealTimers()
   })
 
   it("throws when auth missing", async () => {
@@ -235,6 +236,7 @@ describe("codex plugin", () => {
   })
 
   it("adds token lines from codex ccusage format and passes codex provider", async () => {
+    const plugin = await loadPlugin()
     vi.useFakeTimers()
     vi.setSystemTime(new Date("2026-02-20T16:00:00.000Z"))
 
@@ -264,7 +266,6 @@ describe("codex plugin", () => {
     })
 
     try {
-      const plugin = await loadPlugin()
       const result = plugin.probe(ctx)
 
       const today = result.lines.find((l) => l.label === "Today")
@@ -470,6 +471,7 @@ describe("codex plugin", () => {
   })
 
   it("matches UTC timestamp day keys at month boundary (regression)", async () => {
+    const plugin = await loadPlugin()
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2026, 2, 1, 12, 0, 0))
     try {
@@ -488,7 +490,6 @@ describe("codex plugin", () => {
         data: { daily: [{ date: "2026-03-01T12:00:00Z", totalTokens: 10, costUSD: 0.1 }] },
       })
 
-      const plugin = await loadPlugin()
       const result = plugin.probe(ctx)
       const todayLine = result.lines.find((line) => line.label === "Today")
       expect(todayLine).toBeTruthy()
@@ -499,6 +500,7 @@ describe("codex plugin", () => {
   })
 
   it("matches UTC+9 timestamp day keys at month boundary (regression)", async () => {
+    const plugin = await loadPlugin()
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2026, 2, 1, 12, 0, 0))
     try {
@@ -517,7 +519,6 @@ describe("codex plugin", () => {
         data: { daily: [{ date: "2026-03-01T00:30:00+09:00", totalTokens: 20, costUSD: 0.2 }] },
       })
 
-      const plugin = await loadPlugin()
       const result = plugin.probe(ctx)
       const todayLine = result.lines.find((line) => line.label === "Today")
       expect(todayLine).toBeTruthy()
@@ -528,6 +529,7 @@ describe("codex plugin", () => {
   })
 
   it("matches UTC-8 timestamp day keys at day boundary (regression)", async () => {
+    const plugin = await loadPlugin()
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2026, 2, 1, 12, 0, 0))
     try {
@@ -546,7 +548,6 @@ describe("codex plugin", () => {
         data: { daily: [{ date: "2026-03-01T23:30:00-08:00", totalTokens: 30, costUSD: 0.3 }] },
       })
 
-      const plugin = await loadPlugin()
       const result = plugin.probe(ctx)
       const todayLine = result.lines.find((line) => line.label === "Today")
       expect(todayLine).toBeTruthy()
@@ -1063,6 +1064,7 @@ describe("codex plugin", () => {
   })
 
   it("formats large token totals using compact units", async () => {
+    const plugin = await loadPlugin()
     vi.useFakeTimers()
     vi.setSystemTime(new Date("2026-12-15T12:00:00.000Z"))
     try {
@@ -1093,7 +1095,6 @@ describe("codex plugin", () => {
         },
       })
 
-      const plugin = await loadPlugin()
       const result = plugin.probe(ctx)
       const today = result.lines.find((line) => line.label === "Today")
       const last30 = result.lines.find((line) => line.label === "Last 30 Days")

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -27,6 +27,8 @@ const state = vi.hoisted(() => ({
   saveGlobalShortcutMock: vi.fn(),
   loadStartOnLoginMock: vi.fn(),
   saveStartOnLoginMock: vi.fn(),
+  loadUsageHistoryMock: vi.fn(),
+  saveUsageHistoryMock: vi.fn(),
   autostartEnableMock: vi.fn(),
   autostartDisableMock: vi.fn(),
   autostartIsEnabledMock: vi.fn(),
@@ -242,6 +244,15 @@ vi.mock("@/lib/settings", async () => {
   }
 })
 
+vi.mock("@/lib/usage-history", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/usage-history")>("@/lib/usage-history")
+  return {
+    ...actual,
+    loadUsageHistory: state.loadUsageHistoryMock,
+    saveUsageHistory: state.saveUsageHistoryMock,
+  }
+})
+
 import { App } from "@/App"
 import { useAppPluginStore } from "@/stores/app-plugin-store"
 import { useAppPreferencesStore } from "@/stores/app-preferences-store"
@@ -278,6 +289,8 @@ describe("App", () => {
     state.saveGlobalShortcutMock.mockReset()
     state.loadStartOnLoginMock.mockReset()
     state.saveStartOnLoginMock.mockReset()
+    state.loadUsageHistoryMock.mockReset()
+    state.saveUsageHistoryMock.mockReset()
     state.autostartEnableMock.mockReset()
     state.autostartDisableMock.mockReset()
     state.autostartIsEnabledMock.mockReset()
@@ -316,6 +329,8 @@ describe("App", () => {
     state.saveGlobalShortcutMock.mockResolvedValue(undefined)
     state.loadStartOnLoginMock.mockResolvedValue(false)
     state.saveStartOnLoginMock.mockResolvedValue(undefined)
+    state.loadUsageHistoryMock.mockResolvedValue({})
+    state.saveUsageHistoryMock.mockResolvedValue(undefined)
     state.autostartEnableMock.mockResolvedValue(undefined)
     state.autostartDisableMock.mockResolvedValue(undefined)
     state.autostartIsEnabledMock.mockResolvedValue(false)

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -421,6 +421,58 @@ describe("App", () => {
     expect(state.setSizeMock).toHaveBeenCalled()
   })
 
+  it("keeps bootstrapped usage history when first probe result arrives during startup batch", async () => {
+    state.isTauriMock.mockReturnValue(true)
+    state.loadUsageHistoryMock.mockResolvedValue({
+      b: [{
+        day: "2026-04-20",
+        capturedAt: "2026-04-20T00:00:00.000Z",
+        label: "Requests",
+        used: 12,
+        limit: 100,
+        format: { kind: "count", suffix: "req" },
+      }],
+    })
+    state.invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === "list_plugins") {
+        return [
+          {
+            id: "a",
+            name: "Alpha",
+            iconUrl: "icon-a",
+            primaryCandidates: ["Requests"],
+            lines: [{ type: "progress", label: "Requests", scope: "overview" }],
+          },
+          {
+            id: "b",
+            name: "Beta",
+            iconUrl: "icon-b",
+            primaryCandidates: ["Requests"],
+            lines: [{ type: "progress", label: "Requests", scope: "overview" }],
+          },
+        ]
+      }
+      return null
+    })
+    state.startBatchMock.mockImplementation(async (ids?: string[]) => {
+      state.probeHandlers?.onResult({
+        providerId: "a",
+        displayName: "Alpha",
+        iconUrl: "icon-a",
+        lines: [{ type: "progress", label: "Requests", used: 40, limit: 100, format: { kind: "count", suffix: "req" } }],
+      })
+      return ids
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      const history = useAppPluginStore.getState().usageHistory
+      expect(history.b).toBeDefined()
+      expect(history.a).toBeDefined()
+    })
+  })
+
   it("calls migrateLegacyTraySettings before loadMenubarIconStyle during bootstrap", async () => {
     state.isTauriMock.mockReturnValue(true)
     render(<App />)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,6 +97,10 @@ function App() {
   }, [usageHistory])
 
   const usageHistorySaveQueueRef = useRef(Promise.resolve())
+  const setUsageHistoryAndRef = useCallback((nextHistory: typeof usageHistory) => {
+    usageHistoryRef.current = nextHistory
+    setUsageHistory(nextHistory)
+  }, [setUsageHistory])
 
   const handleProbeResult = useCallback((output: PluginOutput) => {
     scheduleProbeTrayUpdateRef.current()
@@ -112,15 +116,14 @@ function App() {
       providerId: output.providerId,
       entry,
     })
-    usageHistoryRef.current = nextHistory
-    setUsageHistory(nextHistory)
+    setUsageHistoryAndRef(nextHistory)
     usageHistorySaveQueueRef.current = usageHistorySaveQueueRef.current
       .catch(() => undefined)
       .then(() => saveUsageHistory(nextHistory))
       .catch((error) => {
         console.error("Failed to save usage history:", error)
       })
-  }, [setUsageHistory])
+  }, [setUsageHistoryAndRef])
 
   const {
     pluginStates,
@@ -155,7 +158,7 @@ function App() {
   const { applyStartOnLogin } = useSettingsBootstrap({
     setPluginSettings,
     setPluginsMeta,
-    setUsageHistory,
+    setUsageHistory: setUsageHistoryAndRef,
     setAutoUpdateInterval,
     setThemeMode,
     setDisplayMode,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef } from "react"
 import { useShallow } from "zustand/react/shallow"
+import type { PluginOutput } from "@/lib/plugin-types"
 import { AppShell } from "@/components/app/app-shell"
 import { useAppPluginViews } from "@/hooks/app/use-app-plugin-views"
 import { useProbe } from "@/hooks/app/use-probe"
@@ -12,6 +13,11 @@ import { useSettingsTheme } from "@/hooks/app/use-settings-theme"
 import { useTrayIcon } from "@/hooks/app/use-tray-icon"
 import { track } from "@/lib/analytics"
 import { REFRESH_COOLDOWN_MS, savePluginSettings } from "@/lib/settings"
+import {
+  createUsageHistoryEntry,
+  recordUsageHistoryEntry,
+  saveUsageHistory,
+} from "@/lib/usage-history"
 import { type PluginContextAction } from "@/components/side-nav"
 import { useAppPluginStore } from "@/stores/app-plugin-store"
 import { useAppPreferencesStore } from "@/stores/app-preferences-store"
@@ -36,12 +42,16 @@ function App() {
     setPluginsMeta,
     pluginSettings,
     setPluginSettings,
+    usageHistory,
+    setUsageHistory,
   } = useAppPluginStore(
     useShallow((state) => ({
       pluginsMeta: state.pluginsMeta,
       setPluginsMeta: state.setPluginsMeta,
       pluginSettings: state.pluginSettings,
       setPluginSettings: state.setPluginSettings,
+      usageHistory: state.usageHistory,
+      setUsageHistory: state.setUsageHistory,
     }))
   )
 
@@ -76,9 +86,41 @@ function App() {
   )
 
   const scheduleProbeTrayUpdateRef = useRef<() => void>(() => {})
-  const handleProbeResult = useCallback(() => {
+  const pluginsMetaRef = useRef(pluginsMeta)
+  useEffect(() => {
+    pluginsMetaRef.current = pluginsMeta
+  }, [pluginsMeta])
+
+  const usageHistoryRef = useRef(usageHistory)
+  useEffect(() => {
+    usageHistoryRef.current = usageHistory
+  }, [usageHistory])
+
+  const usageHistorySaveQueueRef = useRef(Promise.resolve())
+
+  const handleProbeResult = useCallback((output: PluginOutput) => {
     scheduleProbeTrayUpdateRef.current()
-  }, [])
+
+    const meta = pluginsMetaRef.current.find((plugin) => plugin.id === output.providerId)
+    if (!meta) return
+
+    const entry = createUsageHistoryEntry(meta, output)
+    if (!entry) return
+
+    const nextHistory = recordUsageHistoryEntry({
+      history: usageHistoryRef.current,
+      providerId: output.providerId,
+      entry,
+    })
+    usageHistoryRef.current = nextHistory
+    setUsageHistory(nextHistory)
+    usageHistorySaveQueueRef.current = usageHistorySaveQueueRef.current
+      .catch(() => undefined)
+      .then(() => saveUsageHistory(nextHistory))
+      .catch((error) => {
+        console.error("Failed to save usage history:", error)
+      })
+  }, [setUsageHistory])
 
   const {
     pluginStates,
@@ -113,6 +155,7 @@ function App() {
   const { applyStartOnLogin } = useSettingsBootstrap({
     setPluginSettings,
     setPluginsMeta,
+    setUsageHistory,
     setAutoUpdateInterval,
     setThemeMode,
     setDisplayMode,
@@ -179,6 +222,7 @@ function App() {
     pluginSettings,
     pluginsMeta,
     pluginStates,
+    usageHistory,
   })
 
   const pluginSettingsRef = useRef(pluginSettings)

--- a/src/components/provider-card.test.tsx
+++ b/src/components/provider-card.test.tsx
@@ -110,6 +110,41 @@ describe("ProviderCard", () => {
     expect(screen.getByText("342 credits")).toBeInTheDocument()
   })
 
+  it("renders a 7 day trend chart when history is present", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-02-02T12:00:00.000Z"))
+
+    render(
+      <ProviderCard
+        name="Trend"
+        displayMode="used"
+        brandColor="#10b981"
+        usageHistory={[
+          {
+            day: "2026-02-01",
+            capturedAt: "2026-02-01T00:00:00.000Z",
+            label: "Session",
+            used: 25,
+            limit: 100,
+            format: { kind: "percent" },
+          },
+          {
+            day: "2026-02-02",
+            capturedAt: "2026-02-02T00:00:00.000Z",
+            label: "Session",
+            used: 50,
+            limit: 100,
+            format: { kind: "percent" },
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText("7d trend")).toBeInTheDocument()
+    expect(screen.getByRole("img", { name: /7 day used trend/i })).toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
   it("renders quick links and opens URL", async () => {
     render(
       <ProviderCard

--- a/src/components/provider-card.tsx
+++ b/src/components/provider-card.tsx
@@ -9,9 +9,11 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { SkeletonLines } from "@/components/skeleton-lines"
 import { ProviderAvailabilityNote } from "@/components/provider-availability-note"
 import { PluginError } from "@/components/plugin-error"
+import { UsageTrendChart } from "@/components/usage-trend-chart"
 import { useNowTicker } from "@/hooks/use-now-ticker"
 import { REFRESH_COOLDOWN_MS, type DisplayMode, type ResetTimerDisplayMode } from "@/lib/settings"
 import type { ManifestLine, MetricLine, PluginLink } from "@/lib/plugin-types"
+import type { UsageHistoryEntry } from "@/lib/usage-history"
 import type { WindowsProviderAvailabilityNote } from "@/lib/windows-provider-support"
 import { groupLinesByType } from "@/lib/group-lines-by-type"
 import { clamp01, formatCountNumber, formatFixedPrecisionNumber } from "@/lib/utils"
@@ -33,6 +35,8 @@ interface ProviderCardProps {
   onRetry?: () => void
   scopeFilter?: "overview" | "all"
   displayMode: DisplayMode
+  brandColor?: string
+  usageHistory?: UsageHistoryEntry[]
   disabledOverviewLabels?: string[]
   resetTimerDisplayMode?: ResetTimerDisplayMode
   onResetTimerDisplayModeToggle?: () => void
@@ -97,8 +101,10 @@ export function ProviderCard({
   onRetry,
   scopeFilter = "all",
   displayMode,
+  brandColor,
   resetTimerDisplayMode = "relative",
   onResetTimerDisplayModeToggle,
+  usageHistory = [],
   disabledOverviewLabels = [],
 }: ProviderCardProps) {
   const cooldownRemainingMs = useMemo(() => {
@@ -258,6 +264,14 @@ export function ProviderCard({
 
         {!loading && !error && !availabilityNote?.suppressError && (
           <div className="space-y-4">
+            {usageHistory.length > 0 && (
+              <UsageTrendChart
+                history={usageHistory}
+                displayMode={displayMode}
+                brandColor={brandColor}
+                compact={scopeFilter === "overview"}
+              />
+            )}
             {groupLinesByType(filteredLines).map((group, gi) =>
               group.kind === "text" ? (
                 <div key={gi} className="space-y-1">

--- a/src/components/usage-trend-chart.tsx
+++ b/src/components/usage-trend-chart.tsx
@@ -1,0 +1,189 @@
+import { useId, useMemo } from "react"
+import { type DisplayMode } from "@/lib/settings"
+import {
+  buildUsageTrend,
+  type UsageHistoryEntry,
+} from "@/lib/usage-history"
+import { cn } from "@/lib/utils"
+
+interface UsageTrendChartProps {
+  history: UsageHistoryEntry[]
+  displayMode: DisplayMode
+  brandColor?: string
+  compact?: boolean
+}
+
+type ChartPoint = {
+  x: number
+  y: number
+  labelX: number
+  value: number | null
+  day: string
+  shortLabel: string
+}
+
+function buildLinePath(points: ChartPoint[]): string {
+  const segments: string[] = []
+  let drawing = false
+
+  for (const point of points) {
+    if (point.value == null) {
+      drawing = false
+      continue
+    }
+
+    if (!drawing) {
+      segments.push(`M ${point.x} ${point.y}`)
+      drawing = true
+      continue
+    }
+
+    segments.push(`L ${point.x} ${point.y}`)
+  }
+
+  return segments.join(" ")
+}
+
+export function UsageTrendChart({
+  history,
+  displayMode,
+  brandColor,
+  compact = false,
+}: UsageTrendChartProps) {
+  const gradientId = useId().replace(/:/g, "")
+  const trend = useMemo(
+    () => buildUsageTrend({ entries: history, displayMode }),
+    [displayMode, history]
+  )
+
+  const hasAnyPoint = trend.some((point) => point.fraction != null)
+  if (!hasAnyPoint) return null
+
+  const width = 252
+  const height = compact ? 58 : 74
+  const left = 8
+  const top = 8
+  const plotWidth = width - left * 2
+  const plotHeight = compact ? 28 : 40
+  const bottom = top + plotHeight
+
+  const points = trend.map((point, index): ChartPoint => ({
+    x: left + (plotWidth / Math.max(trend.length - 1, 1)) * index,
+    y: point.fraction == null
+      ? bottom
+      : top + (1 - point.fraction) * plotHeight,
+    labelX: left + (plotWidth / Math.max(trend.length - 1, 1)) * index,
+    value: point.fraction,
+    day: point.day,
+    shortLabel: point.shortLabel,
+  }))
+
+  const currentPoint = [...trend].reverse().find((point) => point.entry)
+  const currentPercent = currentPoint?.fraction == null
+    ? null
+    : Math.round(currentPoint.fraction * 100)
+  const modeLabel = displayMode === "used" ? "used" : "left"
+  const stroke = brandColor || "var(--color-chart-2)"
+  const fill = `${stroke}22`
+  const linePath = buildLinePath(points)
+
+  return (
+    <div className="rounded-xl border border-border/70 bg-muted/35 px-2.5 py-2">
+      <div className="mb-1.5 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            7d trend
+          </span>
+          <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: stroke }} />
+        </div>
+        {currentPercent != null && (
+          <span className="text-[11px] text-muted-foreground">
+            {currentPercent}% {modeLabel}
+          </span>
+        )}
+      </div>
+
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-label={`7 day ${modeLabel} trend`}
+        className="block h-auto w-full overflow-visible"
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor={fill} />
+            <stop offset="100%" stopColor="transparent" />
+          </linearGradient>
+        </defs>
+
+        {[0, 0.5, 1].map((fraction) => {
+          const y = top + fraction * plotHeight
+          return (
+            <line
+              key={fraction}
+              x1={left}
+              x2={width - left}
+              y1={y}
+              y2={y}
+              stroke="var(--color-border)"
+              strokeDasharray="2 4"
+            />
+          )
+        })}
+
+        {linePath && (
+          <path
+            d={`${linePath} L ${points[points.length - 1]?.x ?? width - left} ${bottom} L ${points.find((point) => point.value != null)?.x ?? left} ${bottom} Z`}
+            fill={`url(#${gradientId})`}
+          />
+        )}
+        {linePath && (
+          <path
+            d={linePath}
+            fill="none"
+            stroke={stroke}
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        )}
+
+        {points.map((point) =>
+          point.value == null ? (
+            <circle
+              key={point.day}
+              cx={point.x}
+              cy={bottom}
+              r="1.5"
+              fill="var(--color-border)"
+            />
+          ) : (
+            <circle
+              key={point.day}
+              cx={point.x}
+              cy={point.y}
+              r="3"
+              fill="var(--color-card)"
+              stroke={stroke}
+              strokeWidth="1.5"
+            />
+          )
+        )}
+
+        {points.map((point) => (
+          <text
+            key={`${point.day}-label`}
+            x={point.labelX}
+            y={height - 6}
+            textAnchor="middle"
+            fontSize="10"
+            fill="var(--color-muted-foreground)"
+            className={cn(compact && "opacity-80")}
+          >
+            {compact ? point.shortLabel.slice(0, 1) : point.shortLabel}
+          </text>
+        ))}
+      </svg>
+    </div>
+  )
+}

--- a/src/hooks/app/use-app-plugin-views.test.ts
+++ b/src/hooks/app/use-app-plugin-views.test.ts
@@ -41,6 +41,7 @@ describe("useAppPluginViews", () => {
             lastManualRefreshAt: null,
           },
         },
+        usageHistory: {},
       })
     )
 
@@ -71,6 +72,7 @@ describe("useAppPluginViews", () => {
         pluginSettings,
         pluginsMeta: [createPluginMeta("codex", "Codex")],
         pluginStates: {},
+        usageHistory: {},
       })
     )
 
@@ -90,6 +92,7 @@ describe("useAppPluginViews", () => {
           pluginSettings,
           pluginsMeta,
           pluginStates: {},
+          usageHistory: {},
         }),
       { initialProps: { pluginSettings: null } }
     )
@@ -121,6 +124,7 @@ describe("useAppPluginViews", () => {
         pluginSettings,
         pluginsMeta: [createPluginMeta("codex", "Codex")],
         pluginStates: {},
+        usageHistory: {},
       })
     )
 

--- a/src/hooks/app/use-app-plugin-views.ts
+++ b/src/hooks/app/use-app-plugin-views.ts
@@ -3,8 +3,13 @@ import type { ActiveView, NavPlugin } from "@/components/side-nav"
 import type { PluginMeta } from "@/lib/plugin-types"
 import type { PluginSettings } from "@/lib/settings"
 import type { PluginState } from "@/hooks/app/types"
+import type { UsageHistory } from "@/lib/usage-history"
 
-export type DisplayPluginState = { meta: PluginMeta; disabledOverviewLabels: string[] } & PluginState
+export type DisplayPluginState = {
+  meta: PluginMeta
+  disabledOverviewLabels: string[]
+  usageHistory: import("@/lib/usage-history").UsageHistoryEntry[]
+} & PluginState
 
 type UseAppPluginViewsArgs = {
   activeView: ActiveView
@@ -12,6 +17,7 @@ type UseAppPluginViewsArgs = {
   pluginSettings: PluginSettings | null
   pluginsMeta: PluginMeta[]
   pluginStates: Record<string, PluginState>
+  usageHistory: UsageHistory
 }
 
 export function useAppPluginViews({
@@ -20,6 +26,7 @@ export function useAppPluginViews({
   pluginSettings,
   pluginsMeta,
   pluginStates,
+  usageHistory,
 }: UseAppPluginViewsArgs) {
   const displayPlugins = useMemo<DisplayPluginState[]>(() => {
     if (!pluginSettings) return []
@@ -33,10 +40,15 @@ export function useAppPluginViews({
         if (!meta) return null
         const state =
           pluginStates[id] ?? { data: null, loading: false, error: null, lastManualRefreshAt: null }
-        return { meta, ...state, disabledOverviewLabels: pluginSettings.disabledOverviewLabels?.[id] || [] }
+        return {
+          meta,
+          ...state,
+          usageHistory: usageHistory[id] ?? [],
+          disabledOverviewLabels: pluginSettings.disabledOverviewLabels?.[id] || [],
+        }
       })
       .filter((plugin): plugin is DisplayPluginState => Boolean(plugin))
-  }, [pluginSettings, pluginStates, pluginsMeta])
+  }, [pluginSettings, pluginStates, pluginsMeta, usageHistory])
 
   const navPlugins = useMemo<NavPlugin[]>(() => {
     if (!pluginSettings) return []

--- a/src/hooks/app/use-probe-state.ts
+++ b/src/hooks/app/use-probe-state.ts
@@ -3,7 +3,7 @@ import type { PluginOutput } from "@/lib/plugin-types"
 import type { PluginState } from "@/hooks/app/types"
 
 type UseProbeStateArgs = {
-  onProbeResult?: () => void
+  onProbeResult?: (output: PluginOutput) => void
 }
 
 export function useProbeState({ onProbeResult }: UseProbeStateArgs) {
@@ -77,7 +77,7 @@ export function useProbeState({ onProbeResult }: UseProbeStateArgs) {
         },
       }))
 
-      onProbeResult?.()
+      onProbeResult?.(output)
     },
     [getErrorMessage, onProbeResult]
   )

--- a/src/hooks/app/use-probe.ts
+++ b/src/hooks/app/use-probe.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react"
 import { useProbeEvents } from "@/hooks/use-probe-events"
+import type { PluginOutput } from "@/lib/plugin-types"
 import {
   type AutoUpdateIntervalMinutes,
   type PluginSettings,
@@ -11,7 +12,7 @@ import { useProbeState } from "@/hooks/app/use-probe-state"
 type UseProbeArgs = {
   pluginSettings: PluginSettings | null
   autoUpdateInterval: AutoUpdateIntervalMinutes
-  onProbeResult?: () => void
+  onProbeResult?: (output: PluginOutput) => void
 }
 
 export function useProbe({

--- a/src/hooks/app/use-settings-bootstrap.test.ts
+++ b/src/hooks/app/use-settings-bootstrap.test.ts
@@ -14,6 +14,7 @@ const {
   loadGlobalShortcutMock,
   loadMenubarIconStyleMock,
   loadPluginSettingsMock,
+  loadUsageHistoryMock,
   loadResetTimerDisplayModeMock,
   loadStartOnLoginMock,
   loadThemeModeMock,
@@ -33,6 +34,7 @@ const {
   loadGlobalShortcutMock: vi.fn(),
   loadMenubarIconStyleMock: vi.fn(),
   loadPluginSettingsMock: vi.fn(),
+  loadUsageHistoryMock: vi.fn(),
   loadResetTimerDisplayModeMock: vi.fn(),
   loadStartOnLoginMock: vi.fn(),
   loadThemeModeMock: vi.fn(),
@@ -75,12 +77,17 @@ vi.mock("@/lib/settings", () => ({
   savePluginSettings: savePluginSettingsMock,
 }))
 
+vi.mock("@/lib/usage-history", () => ({
+  loadUsageHistory: loadUsageHistoryMock,
+}))
+
 import { useSettingsBootstrap } from "@/hooks/app/use-settings-bootstrap"
 
 function createArgs() {
   return {
     setPluginSettings: vi.fn(),
     setPluginsMeta: vi.fn(),
+    setUsageHistory: vi.fn(),
     setAutoUpdateInterval: vi.fn(),
     setThemeMode: vi.fn(),
     setDisplayMode: vi.fn(),
@@ -108,6 +115,7 @@ describe("useSettingsBootstrap", () => {
     loadGlobalShortcutMock.mockReset()
     loadMenubarIconStyleMock.mockReset()
     loadPluginSettingsMock.mockReset()
+    loadUsageHistoryMock.mockReset()
     loadResetTimerDisplayModeMock.mockReset()
     loadStartOnLoginMock.mockReset()
     loadThemeModeMock.mockReset()
@@ -128,6 +136,7 @@ describe("useSettingsBootstrap", () => {
       },
     ])
     loadPluginSettingsMock.mockResolvedValue({ order: ["codex"], disabled: [] })
+    loadUsageHistoryMock.mockResolvedValue({})
     normalizePluginSettingsMock.mockImplementation((stored) => stored)
     arePluginSettingsEqualMock.mockReturnValue(true)
     loadAutoUpdateIntervalMock.mockResolvedValue(15)

--- a/src/hooks/app/use-settings-bootstrap.ts
+++ b/src/hooks/app/use-settings-bootstrap.ts
@@ -35,10 +35,12 @@ import {
   type ResetTimerDisplayMode,
   type ThemeMode,
 } from "@/lib/settings"
+import { loadUsageHistory, type UsageHistory } from "@/lib/usage-history"
 
 type UseSettingsBootstrapArgs = {
   setPluginSettings: (value: PluginSettings | null) => void
   setPluginsMeta: (value: PluginMeta[]) => void
+  setUsageHistory: (value: UsageHistory) => void
   setAutoUpdateInterval: (value: AutoUpdateIntervalMinutes) => void
   setThemeMode: (value: ThemeMode) => void
   setDisplayMode: (value: DisplayMode) => void
@@ -54,6 +56,7 @@ type UseSettingsBootstrapArgs = {
 export function useSettingsBootstrap({
   setPluginSettings,
   setPluginsMeta,
+  setUsageHistory,
   setAutoUpdateInterval,
   setThemeMode,
   setDisplayMode,
@@ -91,6 +94,13 @@ export function useSettingsBootstrap({
         const normalized = normalizePluginSettings(storedSettings, availablePlugins)
         if (!arePluginSettingsEqual(storedSettings, normalized)) {
           await savePluginSettings(normalized)
+        }
+
+        let storedUsageHistory: UsageHistory = {}
+        try {
+          storedUsageHistory = await loadUsageHistory()
+        } catch (error) {
+          console.error("Failed to load usage history:", error)
         }
 
         let storedInterval = DEFAULT_AUTO_UPDATE_INTERVAL
@@ -156,6 +166,7 @@ export function useSettingsBootstrap({
         if (isMounted) {
           setPluginSettings(normalized)
           setAutoUpdateInterval(storedInterval)
+          setUsageHistory(storedUsageHistory)
           setThemeMode(storedThemeMode)
           setDisplayMode(storedDisplayMode)
           setResetTimerDisplayMode(storedResetTimerDisplayMode)
@@ -198,6 +209,7 @@ export function useSettingsBootstrap({
     setResetTimerDisplayMode,
     setStartOnLogin,
     setThemeMode,
+    setUsageHistory,
     startBatch,
   ])
 

--- a/src/lib/plugin-types.ts
+++ b/src/lib/plugin-types.ts
@@ -1,3 +1,5 @@
+import type { UsageHistoryEntry } from "@/lib/usage-history"
+
 export type ProgressFormat =
   | { kind: "percent" }
   | { kind: "dollars" }
@@ -53,5 +55,6 @@ export type PluginDisplayState = {
   loading: boolean
   error: string | null
   lastManualRefreshAt: number | null
+  usageHistory?: UsageHistoryEntry[]
   disabledOverviewLabels?: string[]
 }

--- a/src/lib/primary-progress.test.ts
+++ b/src/lib/primary-progress.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+
+import { getPrimaryProgressFraction, getPrimaryProgressLine } from "@/lib/primary-progress"
+
+describe("primary-progress", () => {
+  it("returns null when no primary candidate is available", () => {
+    expect(
+      getPrimaryProgressLine(
+        { primaryCandidates: ["Session"] },
+        {
+          providerId: "codex",
+          displayName: "Codex",
+          iconUrl: "",
+          lines: [{ type: "badge", label: "Plan", text: "Plus" }],
+        }
+      )
+    ).toBeNull()
+  })
+
+  it("returns the first matching primary candidate", () => {
+    expect(
+      getPrimaryProgressLine(
+        { primaryCandidates: ["Credits", "Session"] },
+        {
+          providerId: "codex",
+          displayName: "Codex",
+          iconUrl: "",
+          lines: [
+            { type: "progress", label: "Session", used: 25, limit: 100, format: { kind: "percent" } },
+            { type: "progress", label: "Credits", used: 80, limit: 100, format: { kind: "percent" } },
+          ],
+        }
+      )
+    ).toMatchObject({ label: "Credits", used: 80, limit: 100 })
+  })
+
+  it("computes fractions for used and left display modes", () => {
+    expect(getPrimaryProgressFraction({ used: 25, limit: 100 }, "used")).toBe(0.25)
+    expect(getPrimaryProgressFraction({ used: 25, limit: 100 }, "left")).toBe(0.75)
+  })
+
+  it("returns null for zero limits", () => {
+    expect(getPrimaryProgressFraction({ used: 25, limit: 0 }, "used")).toBeNull()
+  })
+})

--- a/src/lib/primary-progress.ts
+++ b/src/lib/primary-progress.ts
@@ -1,0 +1,46 @@
+import type { PluginMeta, PluginOutput } from "@/lib/plugin-types"
+import type { DisplayMode } from "@/lib/settings"
+import { clamp01 } from "@/lib/utils"
+
+export type PrimaryProgressLine = Extract<
+  PluginOutput["lines"][number],
+  { type: "progress"; label: string; used: number; limit: number }
+>
+
+export function isPrimaryProgressLine(
+  line: PluginOutput["lines"][number]
+): line is PrimaryProgressLine {
+  return line.type === "progress"
+}
+
+export function getPrimaryProgressLine(
+  meta: Pick<PluginMeta, "primaryCandidates">,
+  output: PluginOutput | null
+): PrimaryProgressLine | null {
+  if (!output) return null
+  if (!meta.primaryCandidates || meta.primaryCandidates.length === 0) return null
+
+  const primaryLabel = meta.primaryCandidates.find((label) =>
+    output.lines.some((line) => isPrimaryProgressLine(line) && line.label === label)
+  )
+  if (!primaryLabel) return null
+
+  return (
+    output.lines.find(
+      (line): line is PrimaryProgressLine =>
+        isPrimaryProgressLine(line) && line.label === primaryLabel
+    ) ?? null
+  )
+}
+
+export function getPrimaryProgressFraction(
+  line: Pick<PrimaryProgressLine, "used" | "limit">,
+  displayMode: DisplayMode
+): number | null {
+  if (line.limit <= 0) return null
+  const shownAmount =
+    displayMode === "used"
+      ? line.used
+      : line.limit - line.used
+  return clamp01(shownAmount / line.limit)
+}

--- a/src/lib/tray-primary-progress.ts
+++ b/src/lib/tray-primary-progress.ts
@@ -1,7 +1,10 @@
 import type { PluginMeta, PluginOutput } from "@/lib/plugin-types"
 import type { PluginSettings } from "@/lib/settings"
 import { DEFAULT_DISPLAY_MODE, type DisplayMode } from "@/lib/settings"
-import { clamp01 } from "@/lib/utils"
+import {
+  getPrimaryProgressFraction,
+  getPrimaryProgressLine,
+} from "@/lib/primary-progress"
 
 type PluginState = {
   data: PluginOutput | null
@@ -12,15 +15,6 @@ type PluginState = {
 export type TrayPrimaryBar = {
   id: string
   fraction?: number
-}
-
-type ProgressLine = Extract<
-  PluginOutput["lines"][number],
-  { type: "progress"; label: string; used: number; limit: number }
->
-
-function isProgressLine(line: PluginOutput["lines"][number]): line is ProgressLine {
-  return line.type === "progress"
 }
 
 export function getTrayPrimaryBars(args: {
@@ -61,23 +55,11 @@ export function getTrayPrimaryBars(args: {
 
     let fraction: number | undefined
     if (data) {
-      // Find first candidate that exists in runtime data
-      const primaryLabel = meta.primaryCandidates.find((label) =>
-        data.lines.some((line) => isProgressLine(line) && line.label === label)
-      )
-      if (primaryLabel) {
-        const primaryLine = data.lines.find(
-          (line): line is ProgressLine =>
-            isProgressLine(line) && line.label === primaryLabel
-        )
-        if (primaryLine && primaryLine.limit > 0) {
-          const shownAmount =
-            displayMode === "used"
-              ? primaryLine.used
-              : primaryLine.limit - primaryLine.used
-          fraction = clamp01(shownAmount / primaryLine.limit)
-        }
-      }
+      const primaryLine = getPrimaryProgressLine(meta, data)
+      const nextFraction = primaryLine
+        ? getPrimaryProgressFraction(primaryLine, displayMode)
+        : null
+      if (nextFraction != null) fraction = nextFraction
     }
 
     out.push({ id, fraction })
@@ -86,4 +68,3 @@ export function getTrayPrimaryBars(args: {
 
   return out
 }
-

--- a/src/lib/usage-history.test.ts
+++ b/src/lib/usage-history.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  buildUsageTrend,
+  createUsageHistoryEntry,
+  loadUsageHistory,
+  recordUsageHistoryEntry,
+  sanitizeUsageHistory,
+  saveUsageHistory,
+  type UsageHistory,
+} from "@/lib/usage-history"
+
+const storeState = new Map<string, unknown>()
+const storeSaveMock = vi.fn()
+
+vi.mock("@tauri-apps/plugin-store", () => ({
+  LazyStore: class {
+    async get<T>(key: string): Promise<T | null> {
+      if (!storeState.has(key)) return undefined as T | null
+      return storeState.get(key) as T | null
+    }
+    async set<T>(key: string, value: T): Promise<void> {
+      storeState.set(key, value)
+    }
+    async save(): Promise<void> {
+      storeSaveMock()
+    }
+  },
+}))
+
+describe("usage-history", () => {
+  beforeEach(() => {
+    storeState.clear()
+    storeSaveMock.mockReset()
+  })
+
+  it("sanitizes malformed history payloads", () => {
+    expect(
+      sanitizeUsageHistory({
+        codex: [
+          {
+            day: "2026-04-20",
+            capturedAt: "2026-04-20T10:00:00.000Z",
+            label: "Session",
+            used: 40,
+            limit: 100,
+            format: { kind: "percent" },
+          },
+          {
+            day: "2026-04-21",
+            capturedAt: "2026-04-21T10:00:00.000Z",
+            label: "Session",
+            used: "bad",
+            limit: 100,
+            format: { kind: "percent" },
+          },
+        ],
+      })
+    ).toEqual({
+      codex: [
+        {
+          day: "2026-04-20",
+          capturedAt: "2026-04-20T10:00:00.000Z",
+          label: "Session",
+          used: 40,
+          limit: 100,
+          format: { kind: "percent" },
+        },
+      ],
+    })
+  })
+
+  it("loads and saves history", async () => {
+    const history: UsageHistory = {
+      codex: [
+        {
+          day: "2026-04-20",
+          capturedAt: "2026-04-20T10:00:00.000Z",
+          label: "Session",
+          used: 40,
+          limit: 100,
+          format: { kind: "percent" },
+        },
+      ],
+    }
+
+    await saveUsageHistory(history)
+
+    expect(await loadUsageHistory()).toEqual(history)
+    expect(storeSaveMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("creates a history entry from the primary progress line", () => {
+    expect(
+      createUsageHistoryEntry(
+        { primaryCandidates: ["Credits", "Session"] },
+        {
+          providerId: "codex",
+          displayName: "Codex",
+          iconUrl: "",
+          lines: [
+            { type: "progress", label: "Session", used: 55, limit: 100, format: { kind: "percent" } },
+          ],
+        },
+        new Date("2026-04-21T10:00:00.000Z")
+      )
+    ).toEqual({
+      day: "2026-04-21",
+      capturedAt: "2026-04-21T10:00:00.000Z",
+      label: "Session",
+      used: 55,
+      limit: 100,
+      format: { kind: "percent" },
+    })
+  })
+
+  it("keeps only one snapshot per local day and retains the last 7 days", () => {
+    const history: UsageHistory = {
+      codex: [
+        {
+          day: "2026-04-13",
+          capturedAt: "2026-04-13T10:00:00.000Z",
+          label: "Session",
+          used: 10,
+          limit: 100,
+          format: { kind: "percent" },
+        },
+        {
+          day: "2026-04-20",
+          capturedAt: "2026-04-20T10:00:00.000Z",
+          label: "Session",
+          used: 40,
+          limit: 100,
+          format: { kind: "percent" },
+        },
+      ],
+    }
+
+    const next = recordUsageHistoryEntry({
+      history,
+      providerId: "codex",
+      entry: {
+        day: "2026-04-20",
+        capturedAt: "2026-04-20T16:00:00.000Z",
+        label: "Session",
+        used: 60,
+        limit: 100,
+        format: { kind: "percent" },
+      },
+      now: new Date("2026-04-21T10:00:00.000Z"),
+    })
+
+    expect(next.codex).toEqual([
+      {
+        day: "2026-04-20",
+        capturedAt: "2026-04-20T16:00:00.000Z",
+        label: "Session",
+        used: 60,
+        limit: 100,
+        format: { kind: "percent" },
+      },
+    ])
+  })
+
+  it("builds a 7-day trend for used and left display modes", () => {
+    const entries = [
+      {
+        day: "2026-04-19",
+        capturedAt: "2026-04-19T10:00:00.000Z",
+        label: "Session",
+        used: 25,
+        limit: 100,
+        format: { kind: "percent" as const },
+      },
+      {
+        day: "2026-04-21",
+        capturedAt: "2026-04-21T10:00:00.000Z",
+        label: "Session",
+        used: 75,
+        limit: 100,
+        format: { kind: "percent" as const },
+      },
+    ]
+
+    expect(
+      buildUsageTrend({
+        entries,
+        displayMode: "used",
+        now: new Date("2026-04-21T10:00:00.000Z"),
+      }).map((point) => point.fraction)
+    ).toEqual([null, null, null, null, 0.25, null, 0.75])
+
+    expect(
+      buildUsageTrend({
+        entries,
+        displayMode: "left",
+        now: new Date("2026-04-21T10:00:00.000Z"),
+      }).map((point) => point.fraction)
+    ).toEqual([null, null, null, null, 0.75, null, 0.25])
+  })
+})

--- a/src/lib/usage-history.ts
+++ b/src/lib/usage-history.ts
@@ -1,0 +1,176 @@
+import { LazyStore } from "@tauri-apps/plugin-store"
+import type { PluginMeta, PluginOutput, ProgressFormat } from "@/lib/plugin-types"
+import type { DisplayMode } from "@/lib/settings"
+import { getPrimaryProgressFraction, getPrimaryProgressLine } from "@/lib/primary-progress"
+
+export type UsageHistoryEntry = {
+  day: string
+  capturedAt: string
+  label: string
+  used: number
+  limit: number
+  format: ProgressFormat
+}
+
+export type UsageHistory = Record<string, UsageHistoryEntry[]>
+
+export type UsageTrendPoint = {
+  day: string
+  shortLabel: string
+  fraction: number | null
+  entry: UsageHistoryEntry | null
+}
+
+export const USAGE_HISTORY_DAYS = 7
+
+const USAGE_HISTORY_STORE_PATH = "usage-history.json"
+const USAGE_HISTORY_KEY = "providers"
+
+const store = new LazyStore(USAGE_HISTORY_STORE_PATH)
+
+function parseLocalDayKey(day: string): Date {
+  const [year, month, date] = day.split("-").map(Number)
+  return new Date(year, (month || 1) - 1, date || 1)
+}
+
+function createLocalDayKey(date: Date): string {
+  const year = date.getFullYear()
+  const month = `${date.getMonth() + 1}`.padStart(2, "0")
+  const day = `${date.getDate()}`.padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+function buildDaySequence(now: Date): string[] {
+  const days: string[] = []
+  for (let offset = USAGE_HISTORY_DAYS - 1; offset >= 0; offset -= 1) {
+    const date = new Date(now)
+    date.setHours(0, 0, 0, 0)
+    date.setDate(date.getDate() - offset)
+    days.push(createLocalDayKey(date))
+  }
+  return days
+}
+
+function isProgressFormat(value: unknown): value is ProgressFormat {
+  if (!value || typeof value !== "object") return false
+  const kind = (value as { kind?: unknown }).kind
+  if (kind === "percent" || kind === "dollars") return true
+  return (
+    kind === "count" &&
+    typeof (value as { suffix?: unknown }).suffix === "string"
+  )
+}
+
+function sanitizeEntry(value: unknown): UsageHistoryEntry | null {
+  if (!value || typeof value !== "object") return null
+
+  const maybeEntry = value as Partial<UsageHistoryEntry>
+  if (
+    typeof maybeEntry.day !== "string" ||
+    typeof maybeEntry.capturedAt !== "string" ||
+    typeof maybeEntry.label !== "string" ||
+    typeof maybeEntry.used !== "number" ||
+    typeof maybeEntry.limit !== "number" ||
+    !isProgressFormat(maybeEntry.format)
+  ) {
+    return null
+  }
+
+  if (!Number.isFinite(maybeEntry.used) || !Number.isFinite(maybeEntry.limit)) {
+    return null
+  }
+
+  return {
+    day: maybeEntry.day,
+    capturedAt: maybeEntry.capturedAt,
+    label: maybeEntry.label,
+    used: maybeEntry.used,
+    limit: maybeEntry.limit,
+    format: maybeEntry.format,
+  }
+}
+
+export function sanitizeUsageHistory(value: unknown): UsageHistory {
+  if (!value || typeof value !== "object") return {}
+
+  const history: UsageHistory = {}
+  for (const [providerId, entries] of Object.entries(value as Record<string, unknown>)) {
+    if (!Array.isArray(entries)) continue
+    const sanitizedEntries = entries
+      .map(sanitizeEntry)
+      .filter((entry): entry is UsageHistoryEntry => entry !== null)
+      .sort((a, b) => a.day.localeCompare(b.day))
+
+    if (sanitizedEntries.length > 0) {
+      history[providerId] = sanitizedEntries
+    }
+  }
+
+  return history
+}
+
+export async function loadUsageHistory(): Promise<UsageHistory> {
+  const stored = await store.get<unknown>(USAGE_HISTORY_KEY)
+  return sanitizeUsageHistory(stored)
+}
+
+export async function saveUsageHistory(history: UsageHistory): Promise<void> {
+  await store.set(USAGE_HISTORY_KEY, history)
+  await store.save()
+}
+
+export function createUsageHistoryEntry(
+  meta: Pick<PluginMeta, "primaryCandidates">,
+  output: PluginOutput,
+  now: Date = new Date()
+): UsageHistoryEntry | null {
+  const primaryLine = getPrimaryProgressLine(meta, output)
+  if (!primaryLine) return null
+
+  return {
+    day: createLocalDayKey(now),
+    capturedAt: now.toISOString(),
+    label: primaryLine.label,
+    used: primaryLine.used,
+    limit: primaryLine.limit,
+    format: primaryLine.format,
+  }
+}
+
+export function recordUsageHistoryEntry(args: {
+  history: UsageHistory
+  providerId: string
+  entry: UsageHistoryEntry
+  now?: Date
+}): UsageHistory {
+  const { history, providerId, entry, now = new Date() } = args
+  const keepDays = new Set(buildDaySequence(now))
+  const currentEntries = history[providerId] ?? []
+  const keptEntries = currentEntries.filter((item) => keepDays.has(item.day) && item.day !== entry.day)
+  const nextEntries = [...keptEntries, entry].sort((a, b) => a.day.localeCompare(b.day))
+
+  return {
+    ...history,
+    [providerId]: nextEntries,
+  }
+}
+
+export function buildUsageTrend(args: {
+  entries: UsageHistoryEntry[]
+  displayMode: DisplayMode
+  now?: Date
+}): UsageTrendPoint[] {
+  const { entries, displayMode, now = new Date() } = args
+  const byDay = new Map(entries.map((entry) => [entry.day, entry]))
+
+  return buildDaySequence(now).map((day) => {
+    const date = parseLocalDayKey(day)
+    const entry = byDay.get(day) ?? null
+    return {
+      day,
+      shortLabel: new Intl.DateTimeFormat(undefined, { weekday: "short" }).format(date),
+      fraction: entry ? getPrimaryProgressFraction(entry, displayMode) : null,
+      entry,
+    }
+  })
+}

--- a/src/pages/overview.tsx
+++ b/src/pages/overview.tsx
@@ -33,6 +33,7 @@ export function OverviewPage({
           key={plugin.meta.id}
           name={plugin.meta.name}
           plan={plugin.data?.plan}
+          brandColor={plugin.meta.brandColor}
           availabilityNote={getWindowsProviderAvailabilityNote(plugin)}
           showSeparator={index < plugins.length - 1}
           loading={plugin.loading}
@@ -40,6 +41,7 @@ export function OverviewPage({
           lines={plugin.data?.lines ?? []}
           skeletonLines={plugin.meta.lines}
           lastManualRefreshAt={plugin.lastManualRefreshAt}
+          usageHistory={plugin.usageHistory}
           onRetry={onRetryPlugin ? () => onRetryPlugin(plugin.meta.id) : undefined}
           scopeFilter="overview"
           displayMode={displayMode}

--- a/src/pages/provider-detail.tsx
+++ b/src/pages/provider-detail.tsx
@@ -31,6 +31,7 @@ export function ProviderDetailPage({
       name={plugin.meta.name}
       plan={plugin.data?.plan}
       links={plugin.meta.links}
+      brandColor={plugin.meta.brandColor}
       availabilityNote={getWindowsProviderAvailabilityNote(plugin)}
       showSeparator={false}
       loading={plugin.loading}
@@ -38,6 +39,7 @@ export function ProviderDetailPage({
       lines={plugin.data?.lines ?? []}
       skeletonLines={plugin.meta.lines}
       lastManualRefreshAt={plugin.lastManualRefreshAt}
+      usageHistory={plugin.usageHistory}
       onRetry={onRetry}
       scopeFilter="all"
       displayMode={displayMode}

--- a/src/stores/app-plugin-store.ts
+++ b/src/stores/app-plugin-store.ts
@@ -1,23 +1,28 @@
 import { create } from "zustand"
 import type { PluginMeta } from "@/lib/plugin-types"
 import type { PluginSettings } from "@/lib/settings"
+import type { UsageHistory } from "@/lib/usage-history"
 
 type AppPluginStore = {
   pluginsMeta: PluginMeta[]
   pluginSettings: PluginSettings | null
+  usageHistory: UsageHistory
   setPluginsMeta: (value: PluginMeta[]) => void
   setPluginSettings: (value: PluginSettings | null) => void
+  setUsageHistory: (value: UsageHistory) => void
   resetState: () => void
 }
 
 const initialState = {
   pluginsMeta: [] as PluginMeta[],
   pluginSettings: null as PluginSettings | null,
+  usageHistory: {} as UsageHistory,
 }
 
 export const useAppPluginStore = create<AppPluginStore>((set) => ({
   ...initialState,
   setPluginsMeta: (value) => set({ pluginsMeta: value }),
   setPluginSettings: (value) => set({ pluginSettings: value }),
+  setUsageHistory: (value) => set({ usageHistory: value }),
   resetState: () => set(initialState),
 }))


### PR DESCRIPTION
## Summary

- Add persisted per-provider daily usage history with a rolling 7-day retention window.
- Render inline 7-day trend charts in overview and provider detail views.
- Reuse shared primary-progress selection logic across tray rendering and history capture.

---

## Context / Background

- UsageTray showed only current provider usage snapshots. This change adds lightweight local history so users can see short-term direction without leaving the tray UI.

---

## Changes Made

- Added history persistence/derivation helpers and tests for daily snapshot retention, sanitization, and trend building.
- Wired successful probe results into app state so provider history loads on bootstrap, updates after successful probes, and remains separate from unrelated working tree changes.
- Added a compact SVG trend card in provider views and updated README plus breadcrumb/choices notes to document the behavior.

---

## How to Test

1. Run `bunx vitest run src/lib/primary-progress.test.ts src/lib/usage-history.test.ts src/components/provider-card.test.tsx src/hooks/app/use-app-plugin-views.test.ts src/hooks/app/use-settings-bootstrap.test.ts src/pages/overview.test.tsx src/pages/provider-detail.test.tsx`.
2. Run `bunx vitest run src/App.test.tsx src/components/app/app-content.test.tsx`.
3. Run `bun run build`.

---

## Breaking Changes

- None.

---

## Deployment Notes

- None.

---

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated
- [x] No console logs / debug code
- [x] Documentation updated
- [x] Self-review completed

---

## Related Issues

- None.

---

## Observability Impact

- None.

---

## Security Considerations

- None.

---

## Performance Impact

- Low. Adds small local store reads/writes and a lightweight inline SVG chart per visible provider.
